### PR TITLE
docs: point the README at v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,14 @@
 [![docker](https://github.com/MacAnalog/spicexplorer-release/actions/workflows/docker.yml/badge.svg)](https://github.com/MacAnalog/spicexplorer-release/actions/workflows/docker.yml)
 
 Open-source releases from the SpiceXplorer analog design-automation project,
-developed by the MacAnalog research group at McMaster University. As of **v1.0**
-the whole platform is public — every package, the Studio front-end, and the
-circuit database — each published as a curated snapshot.
+developed by the MacAnalog research group at McMaster University. The whole
+platform is public — every package, the Studio front-end, and the circuit
+database — each published as a curated snapshot.
+
+**Current release: v1.1.** It adds the EDA base image, so `make up-live` gives
+you a working simulator and three open PDKs with nothing installed on the host
+(see [Live SPICE](#quickstart) below). v1.0 opened the platform: all ten
+packages, the UI, and the database.
 
 ## Components
 


### PR DESCRIPTION
The README banner still announced **v1.0** as the current release.

## What was done

- Name **v1.1** as the current release and say what it adds — the EDA base
  image, so `make up-live` gives a working simulator and three open PDKs with
  nothing installed on the host.
- Keep v1.0 described as what it actually was: the release that opened the whole
  platform (all ten packages, the UI, the database). The scope sentence above it
  is now tense-neutral, so it stops needing an edit every release.

## Errors / setbacks / gotchas

- `main` is protected, so this could not go in as a direct commit alongside the
  tag — hence the branch.

## Next Steps

- Tag **v1.1** once this lands, so the tag points at a README that names it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Vu6GeW5ghLBGCT6T8A6hf