### PR TITLE
docs: the component table and Docker docs had drifted behind what ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ directly — phase margin, unity-gain frequency, and the peak of the sensitivity
 function — rather than inferring stability from output-impedance peaking, and
 fixes a dropout sweep that ended below the voltage at which one regulator
 reaches regulation. v1.1.1 moved the reference circuits to upstream pointers
-and refreshed the database (faster test tiers, publication-quality
+and refreshed the database (reorganized test tiers, regenerated
 schematics). v1.1 added the EDA base image, so `make up-live` gives
 you a working simulator and three open PDKs with nothing installed on the host
 (see [Live SPICE](#quickstart) below). v1.0 opened the platform: all ten
@@ -31,7 +31,7 @@ packages, the UI, and the database.
 | [`analog-db/`](analog-db/) | Analog circuit database — the topology/circuit registry (netlists, datasheets, class libraries, testbench templates) and its tiered verification harness | released |
 | [`platform/`](platform/) | The Python workspace — kernel, leaf tools, optimizer and REST API (all ten packages below) | released |
 | [`ui/`](ui/) | SpiceXplorer "Studio" — the Next.js front-end (HTTP/SSE) over the platform api | released |
-| [`agentic-design-example/`](agentic-design-example/) | A worked agent-driven design, as a submodule — the PAM-4 2-bit current-steering DAC driver taken from spec to layout in IHP SG13G2, with every schematic/layout co-design round on the record | released |
+| [`agentic-design-example/`](agentic-design-example/) | A worked agent-driven design, as a submodule — the PAM-4 2-bit current-steering DAC driver taken from spec to layout in IHP SG13G2, with every schematic/layout co-design round recorded | released |
 | [`.claude/`](.claude/) | The agent kit: the four layout-lane agent definitions (brief → design → review → co-design) and the two gm/ID sizing skills, block- and PDK-agnostic | released |
 
 ### Platform packages
@@ -42,14 +42,14 @@ other, so any one of them can be used on its own.
 
 | Package | Layer | What it does |
 |---|---|---|
-| `spicexplorer-api` | adapter | FastAPI service over the optimizer and the library — thin, no business logic |
+| `spicexplorer-api` | adapter | FastAPI service over the optimizer and the library — no business logic |
 | `spicexplorer` | optimizer | The YAML design DSL, the scoring/optimization loop, and the simulation backends |
 | `spicexplorer-circuitgraph` | leaf tool | Netlist → typed bipartite graph (nets ⟷ components), with round-trip and cross-PDK retargeting |
 | `spicexplorer-netlist2xschem` | leaf tool | Netlist → xschem schematic, with headless SVG/PNG rendering |
-| `spicexplorer-netlist2tf` | leaf tool | Netlist → exact symbolic transfer function, reduced to readable hand-form |
+| `spicexplorer-netlist2tf` | leaf tool | Netlist → exact symbolic transfer function, reduced to the form used in hand analysis |
 | `spicexplorer-gmid` | leaf tool | Deterministic gm/ID sizing from pre-computed lookup tables |
-| `spicexplorer-waveview` | leaf tool | Universal result viewer — ngspice/Spectre artifacts → engine-neutral waveforms + plots |
-| `spicexplorer-layout` | leaf tool | Layout as code — the parameterized generator contract + deterministic GDS build, annotated review renders, the post-layout measure protocol, and full-wave EM verification (openEMS) |
+| `spicexplorer-waveview` | leaf tool | Result viewer — ngspice/Spectre artifacts → engine-neutral waveforms + plots |
+| `spicexplorer-layout` | leaf tool | Parameterized layout generation: the generator contract, deterministic GDS build, annotated review renders, the post-layout measure protocol, and full-wave EM verification (openEMS) |
 | `spicexplorer-signoff` | leaf tool | Physical signoff — DRC / LVS / PEX runners with structured verdicts, chained build → DRC → LVS → PEX by one call, plus post-layout splicing and parasitic/mismatch injection |
 | `spicexplorer-core` | kernel | SPICE-engine wrappers, PVT corners, measurements, units, path anchoring |
 
@@ -57,12 +57,12 @@ Each component keeps its own `README.md`, `LICENSE`, and (for Python) `pyproject
 a `.release-provenance.json` in each records the snapshot it was cut from.
 
 > **PDKs.** The database ships **open** PDK bindings only — IHP sg13g2, SkyWater
-> sky130, and GlobalFoundries gf180mcu. The Spectre/commercial lane's machinery,
+> sky130, and GlobalFoundries gf180mcu. The Spectre/commercial lane's code,
 > templates and tests are here **kit-unbound**: no proprietary kit is bound, and
 > no foundry-NDA-encumbered content — models, device or corner names, library
 > identifiers, or data derived from a licensed kit — ships anywhere in this
 > repository (CI enforces this: `nda-check`). You bind your own kit through the
-> documented seam.
+> documented binding interface.
 
 ## Quickstart
 
@@ -110,9 +110,9 @@ each `make` target is a one-line wrapper you can run by hand.
 > source with OSDI, plus the IHP sg13g2, SkyWater sky130 and GF gf180mcu PDKs
 > vendored** (all Apache-2.0) — and runs the stack on top of it. `pdk_ok:true`,
 > with **nothing installed on the host**: no ngspice, no PDK download, no
-> `PDK_ROOT`. It builds on both x86-64 and arm64 (Apple silicon) — the compact
-> models are compiled from source there, which takes considerably longer the
-> first time. See
+> `PDK_ROOT`. It builds on both x86-64 and arm64 (Apple silicon). The arm64
+> path compiles the compact models from source rather than reusing the prebuilt
+> x86-64 ones, so its first build is the slower of the two. See
 > [docs/docker.md](docs/docker.md#live-spice-in-the-container).
 >
 > Prefer no containers? Install a local ngspice + an open PDK and run natively —
@@ -121,9 +121,10 @@ each `make` target is a one-line wrapper you can run by hand.
 > **`docker compose --profile em build em`** builds a third, separate image
 > ([`Dockerfile.em`](Dockerfile.em)) — **openEMS compiled from source plus the
 > IHP PDK's own openEMS workflow** — for the full-wave verification lane in
-> `spicexplorer-layout`. It has its own profile because the stack is heavy and
-> the lane is for confirming a reflection or balance claim after the fact, never
-> for the optimizer loop: a plain `make up` never builds it. See
+> `spicexplorer-layout`. It has its own profile because the image adds a
+> from-source C++ build (boost, VTK, CGAL), and because the lane runs outside the
+> per-trial optimization loop, on the accepted layout only: a plain `make up`
+> never builds it. See
 > [docs/docker.md](docs/docker.md#what-runs).
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ other, so any one of them can be used on its own.
 | `spicexplorer-netlist2tf` | leaf tool | Netlist → exact symbolic transfer function, reduced to readable hand-form |
 | `spicexplorer-gmid` | leaf tool | Deterministic gm/ID sizing from pre-computed lookup tables |
 | `spicexplorer-waveview` | leaf tool | Universal result viewer — ngspice/Spectre artifacts → engine-neutral waveforms + plots |
-| `spicexplorer-layout` | leaf tool | Parameterized layout generation (the generator contract + GDS build) |
-| `spicexplorer-signoff` | leaf tool | Physical signoff — DRC / LVS / PEX runners with structured verdicts |
+| `spicexplorer-layout` | leaf tool | Layout as code — the parameterized generator contract + deterministic GDS build, annotated review renders, the post-layout measure protocol, and full-wave EM verification (openEMS) |
+| `spicexplorer-signoff` | leaf tool | Physical signoff — DRC / LVS / PEX runners with structured verdicts, chained build → DRC → LVS → PEX by one call, plus post-layout splicing and parasitic/mismatch injection |
 | `spicexplorer-core` | kernel | SPICE-engine wrappers, PVT corners, measurements, units, path anchoring |
 
 Each component keeps its own `README.md`, `LICENSE`, and (for Python) `pyproject.toml`;
@@ -117,6 +117,14 @@ each `make` target is a one-line wrapper you can run by hand.
 >
 > Prefer no containers? Install a local ngspice + an open PDK and run natively —
 > see [docs/getting-started.md](docs/getting-started.md#live-spice-optional).
+>
+> **`docker compose --profile em build em`** builds a third, separate image
+> ([`Dockerfile.em`](Dockerfile.em)) — **openEMS compiled from source plus the
+> IHP PDK's own openEMS workflow** — for the full-wave verification lane in
+> `spicexplorer-layout`. It has its own profile because the stack is heavy and
+> the lane is for confirming a reflection or balance claim after the fact, never
+> for the optimizer loop: a plain `make up` never builds it. See
+> [docs/docker.md](docs/docker.md#what-runs).
 
 ## Documentation
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -29,6 +29,7 @@ make down               # stop (== docker compose down)
 | `api` | `spicexplorer-api:release` | `8000` | [`Dockerfile.api`](../Dockerfile.api) (context = repo root) |
 | `ui`  | `spicexplorer-ui:release`  | `4000` | [`ui/Dockerfile.prod`](../ui/Dockerfile.prod) (Next.js standalone) |
 | `spice-base` | `spicexplorer-spice-base:release` | — | [`Dockerfile.spice-base`](../Dockerfile.spice-base). `live` profile: built only by `make up-live`, never started — the `api` `FROM`s it |
+| `em` | `spicexplorer-em:release` | — | [`Dockerfile.em`](../Dockerfile.em). `em` profile: the full-wave verification toolchain (openEMS from source + the IHP PDK's openEMS workflow) for `spicexplorer_layout.em`. Build with `docker compose --profile em build em`, then `docker compose run --rm em bash`; it carries the toolchain only, so mount your work dir (`WORKDIR=...`) and run against an installed `spicexplorer-layout` |
 
 Wiring: the UI is built with `BACKEND_URL=http://api:8000`, so the browser talks
 only to `:4000` and the UI proxies `/api/*` to the `api` service over the compose

--- a/platform/.release-provenance.json
+++ b/platform/.release-provenance.json
@@ -3,5 +3,5 @@
   "source": "release-src/platform",
   "source_sha": "f0d5c4430c2092ea5a05d66c62fb9ab498e93646",
   "file_count": 898,
-  "ported_at": "2026-09-01T19:00:35+00:00"
+  "ported_at": "2026-09-01T20:30:16+00:00"
 }

--- a/platform/.release-provenance.json
+++ b/platform/.release-provenance.json
@@ -3,5 +3,5 @@
   "source": "release-src/platform",
   "source_sha": "f0d5c4430c2092ea5a05d66c62fb9ab498e93646",
   "file_count": 898,
-  "ported_at": "2026-09-01T20:30:16+00:00"
+  "ported_at": "2026-09-01T20:43:57+00:00"
 }


### PR DESCRIPTION
Owner review of the merged EM increment (#8) caught the component table
describing packages as they were, not as they ship. No code changes.

## What was done

- **`spicexplorer-layout`** was described as "Parameterized layout generation
  (the generator contract + GDS build)" — one of four things the package does.
  It also renders annotated review images with numbered, severity-coloured
  findings (`review.py`), carries the post-layout measure protocol the
  optimizer's layout backend speaks (`measure_protocol.py`), and now runs the
  openEMS full-wave EM lane (`em.py`). That last one shipped in #8 while this
  row went untouched.
- **`spicexplorer-signoff`** had drifted the same way, less badly: the row named
  the DRC/LVS/PEX runners but not `run_flow` — which chains build → DRC → LVS →
  PEX and is the actual entry point — nor the two netlist-side helpers
  (post-layout splice; parasitic/mismatch injection, the primitive behind the
  layout brief).
- **`Dockerfile.em` shipped undocumented.** It landed at the release root with an
  `em` compose profile in #8, and neither the README nor `docs/docker.md`
  mentioned openEMS, the profile, or the file — the only way to find the image
  was to read `compose.yaml`. `docs/docker.md`'s "What runs" table gains the `em`
  service row; the README's Docker note gains a paragraph on what it is, how to
  build it, and why it is profile-gated.

## Verification

Re-ported and gated in the private tree: leak scan **0 deny**, repo-files scan
**0 deny** across 35 root files, **11/11** platform check commands PASS. Public
CI on this PR re-runs the full set.

## Assumptions

- Both rows stay one line, matching the sibling entries; the detail lives in each
  package's own README rather than being duplicated here.
- README "Current release" still reads v1.1.2 — this does not claim a version.

## Errors / setbacks / gotchas

- **The component table is hand-maintained and generated from nothing**, so it
  drifts silently: adding a module to a package does not touch it, and no gate
  notices. The same is true of `docs/docker.md`'s service table — a whole image
  shipped without either file mentioning it. Worth a checklist item on any
  increment that adds a module or a compose service.

## Next Steps

- Merge order: this PR, then
  [spicexplorer-workspace#91](https://github.com/MacAnalog/spicexplorer-workspace/pull/91),
  which carries these files' sources under `scripts/release/repo/`.
- Version bump and tag remain deliberately deferred.
